### PR TITLE
fix(auth): improve registration password feedback

### DIFF
--- a/backend/authentication/serializers.py
+++ b/backend/authentication/serializers.py
@@ -8,6 +8,22 @@ from stripe_meta.models import Subscription
 
 User = get_user_model()
 
+
+class PasswordValidationStringField(serializers.Field):
+    default_error_messages = {'invalid': 'Not a valid string.'}
+
+    def to_internal_value(self, data):
+        if not isinstance(data, str):
+            self.fail('invalid')
+        return data
+
+
+class PasswordValidationSerializer(serializers.Serializer):
+    password = PasswordValidationStringField(default='')
+    username = PasswordValidationStringField(default='')
+    email = PasswordValidationStringField(default='')
+
+
 class OrganizationSerializer(serializers.ModelSerializer):
     plan_id = serializers.SerializerMethodField()
     

--- a/backend/authentication/urls.py
+++ b/backend/authentication/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from rest_framework_simplejwt.views import TokenRefreshView
 from .views import (
     RegisterView,
+    PasswordValidationView,
     VerifyEmailView,
     LoginView,
     LogoutView,
@@ -23,6 +24,7 @@ from .views import (
 
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='register'),
+    path('password/validate/', PasswordValidationView.as_view(), name='password-validate'),
     path('verify/', VerifyEmailView.as_view(), name='verify'),
     path('login/', LoginView.as_view(), name='login'),
     path('logout/', LogoutView.as_view(), name='logout'),

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -8,10 +8,14 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from django.contrib.auth import get_user_model
 from django.contrib.auth import authenticate
-from django.contrib.auth.password_validation import validate_password
+from django.contrib.auth.password_validation import (
+    UserAttributeSimilarityValidator,
+    get_default_password_validators,
+    validate_password,
+)
 from django.core.exceptions import ValidationError
 from rest_framework_simplejwt.tokens import RefreshToken
-from .serializers import UserProfileSerializer, OrganizationTokenRefreshSerializer
+from .serializers import UserProfileSerializer, OrganizationTokenRefreshSerializer, PasswordValidationSerializer
 from .login_security import LoginSecurityService
 from .password_rotation import get_password_rotation_status
 from .services import refresh_organization_access_token
@@ -30,7 +34,7 @@ from core.services.tenant import slug_to_schema_name
 from google_auth_oauthlib.flow import Flow  # For OAuth start (generating auth URL)
 from requests_oauthlib import OAuth2Session  # For OAuth callback (token exchange)
 from django.core.mail import send_mail
-from django.utils import timezone
+from django.utils import timezone, translation
 from core.services.auth_tokens import build_user_refresh_token
 import datetime
 import requests
@@ -74,6 +78,37 @@ def build_google_oauth_state() -> str:
         ttl_seconds=GOOGLE_AUTH_STATE_TTL_SECONDS,
     )
 
+class PasswordValidationView(APIView):
+    authentication_classes = []
+    permission_classes = []
+
+    @translation.override('en')
+    def post(self, request):
+        serializer = PasswordValidationSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        password = data['password']
+        user = User(email=data['email'], username=data['username'])
+        rules = []
+        for validator in get_default_password_validators():
+            errors = []
+            if password:
+                try:
+                    validator.validate(password, user=user)
+                except ValidationError as exc:
+                    errors = list(exc.messages)
+            help_text = str(validator.get_help_text())
+            if isinstance(validator, UserAttributeSimilarityValidator):
+                help_text += ' (Username, Email)'
+            rules.append({
+                'id': validator.__class__.__name__,
+                'help_text': help_text,
+                'valid': not errors if password else None,
+                'errors': errors,
+            })
+        return Response({'rules': rules})
+
+
 @method_decorator(csrf_exempt, name='dispatch')
 class RegisterView(APIView):
     permission_classes = []  
@@ -95,13 +130,14 @@ class RegisterView(APIView):
         # Validate password using Django's password validators
         # Create a temporary user object for validation context
         temp_user = User(email=email, username=username)
-        try:
-            validate_password(password, user=temp_user)
-        except ValidationError as e:
-            return Response({
-                "error": "Password validation failed",
-                "details": list(e.messages)
-            }, status=400)
+        with translation.override('en'):
+            try:
+                validate_password(password, user=temp_user)
+            except ValidationError as e:
+                return Response({
+                    "error": "Password validation failed",
+                    "details": list(e.messages)
+                }, status=400)
 
         # MULTI-ORG: Users must create or join an organization during onboarding
         # No longer auto-create organization during registration

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import AuthFormWrapper from '@/components/auth/AuthFormWrapper';
@@ -8,6 +8,7 @@ import AuthFeedback from '@/components/auth/AuthFeedback';
 import AuthFields from '@/components/auth/AuthFields';
 import AuthSubmit from '@/components/auth/AuthSubmit';
 import RegisterSuccessMessage from '@/components/auth/RegisterSuccessMessage';
+import PasswordRequirements from '@/components/auth/PasswordRequirements';
 import useAuth from '@/hooks/useAuth';
 import { useAuthStore } from '@/lib/authStore';
 import { validateRegistrationForm, hasValidationErrors } from '@/utils/validation';
@@ -33,19 +34,25 @@ export default function RegisterPage() {
   const [loading, setLoading] = useState<boolean>(false);
   const [registrationSuccess, setRegistrationSuccess] = useState<boolean>(false);
   const [registrationMessage, setRegistrationMessage] = useState<string>('');
+  const inputVersion = useRef(0);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
+    if (name === 'password' || name === 'username' || name === 'email') {
+      inputVersion.current += 1;
+    }
     setFormData(prev => ({
       ...prev,
       [name]: value
     }));
     
     // Clear error when user starts typing
-    if (errors[name as keyof FormValidation]) {
+    if (errors[name as keyof FormValidation] ||
+      ((name === 'username' || name === 'email') && errors.password)) {
       setErrors(prev => ({
         ...prev,
-        [name]: ''
+        [name]: '',
+        ...((name === 'username' || name === 'email') ? { password: '' } : {}),
       }));
     }
   };
@@ -75,6 +82,7 @@ export default function RegisterPage() {
     
     console.log('Submitting registration data:', { ...requestData, password: '[HIDDEN]' });
     
+    const submittedVersion = inputVersion.current;
     const result = await register(requestData);
 
     if (result.success) {
@@ -89,7 +97,9 @@ export default function RegisterPage() {
       setRegistrationMessage(result.data?.message || 'Registration successful! Your account is ready to use.');
     } else {
       setLoading(false);
-      setErrors({ general: result.error });
+      if (!result.fieldErrors?.password || submittedVersion === inputVersion.current) {
+        setErrors(result.fieldErrors || { general: result.error });
+      }
     }
   };
 
@@ -176,6 +186,13 @@ export default function RegisterPage() {
               value: formData.password,
               onChange: handleChange,
               error: errors.password,
+              description: (
+                <PasswordRequirements
+                  password={formData.password}
+                  username={formData.username}
+                  email={formData.email}
+                />
+              ),
               required: true,
               placeholder: 'Create a password (min 8 characters)',
             },

--- a/frontend/src/components/auth/AuthFields.tsx
+++ b/frontend/src/components/auth/AuthFields.tsx
@@ -8,6 +8,7 @@ type AuthFieldConfig = {
   value: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   error?: string;
+  description?: React.ReactNode;
   required?: boolean;
   placeholder?: string;
 };
@@ -42,6 +43,7 @@ export default function AuthFields({
           value={field.value}
           onChange={field.onChange}
           error={field.error}
+          description={field.description}
           required={field.required}
           placeholder={field.placeholder}
         />

--- a/frontend/src/components/auth/PasswordRequirements.tsx
+++ b/frontend/src/components/auth/PasswordRequirements.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { authAPI } from '@/lib/api';
+import type { PasswordValidationRule } from '@/types/auth';
+
+type Props = { password: string; username: string; email: string };
+
+export default function PasswordRequirements({ password, username, email }: Props) {
+  const inputKey = JSON.stringify([password, username, email]);
+  const [validation, setValidation] = useState<{
+    inputKey: string;
+    rules: PasswordValidationRule[];
+    unavailable?: boolean;
+  } | null>(null);
+  const current = validation?.inputKey === inputKey;
+  const checking = !current;
+  const rules = validation?.rules || [];
+  const visibleRules = password && current && !validation?.unavailable
+    ? rules.filter(rule => rule.valid === false) : [];
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+    const timer = setTimeout(async () => {
+      try {
+        const result = await authAPI.validatePassword(
+          { password, username, email }, controller.signal,
+        );
+        if (active) setValidation({ inputKey, rules: result.rules });
+      } catch {
+        if (active) {
+          setValidation(previous => ({
+            inputKey, rules: previous?.rules || [], unavailable: true,
+          }));
+        }
+      }
+    }, password ? 300 : 0);
+
+    return () => {
+      active = false;
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [password, username, email, inputKey]);
+
+  return (
+    <div className="space-y-1 text-sm" aria-live="polite" aria-busy={Boolean(password) && checking}>
+      {!password && (
+        <p className="text-gray-500">
+          Password requirement: Use 8+ characters, not just numbers; avoid common passwords or similarity to username/email.
+        </p>
+      )}
+      {visibleRules.length > 0 && (
+        <ul className="space-y-1">
+          {visibleRules.map(rule => (
+            <li key={rule.id} className="flex gap-2 text-red-600">
+              <span aria-hidden="true" className="shrink-0">❌</span>
+              <span>
+                <span className="sr-only">Not met: </span>
+                {rule.errors.join(' ')}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {password && checking && <p className="text-gray-500">Checking password…</p>}
+      {password && current && validation?.unavailable && (
+        <p className="text-gray-600">Password check unavailable. You can still submit to check your password.</p>
+      )}
+      {current && password && !validation?.unavailable && Boolean(validation?.rules.length) &&
+        validation?.rules.every(rule => rule.valid === true) && (
+          <p className="flex items-center gap-2 text-green-700">
+            <span aria-hidden="true" className="shrink-0">✅</span>
+            Password is valid.
+          </p>
+        )}
+    </div>
+  );
+}

--- a/frontend/src/components/form/FormInput.tsx
+++ b/frontend/src/components/form/FormInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState, type ReactNode } from 'react';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 
 interface FormInputProps {
@@ -8,6 +8,7 @@ interface FormInputProps {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   error?: string;
+  description?: ReactNode;
   placeholder?: string;
   required?: boolean;
   className?: string;
@@ -20,24 +21,32 @@ export default function FormInput({
   value,
   onChange,
   error,
+  description,
   placeholder,
   required = false,
   className = ''
 }: FormInputProps) {
   const [showPassword, setShowPassword] = useState(false);
   const [focused, setFocused] = useState(false);
+  const inputId = useId();
 
   const inputType = type === 'password' && showPassword ? 'text' : type;
 
   return (
     <div className={`space-y-2 ${className}`}>
-      <label className="block text-sm font-medium text-gray-700">
+      <label htmlFor={inputId} className="block text-sm font-medium text-gray-700">
         {label}
         {required && <span className="text-red-500">*</span>}
       </label>
 
       <div className="relative">
         <input
+          id={inputId}
+          aria-invalid={Boolean(error)}
+          aria-describedby={[
+            description ? `${inputId}-description` : '',
+            error ? `${inputId}-error` : '',
+          ].filter(Boolean).join(' ') || undefined}
           type={inputType}
           name={name}
           value={value}
@@ -71,8 +80,9 @@ export default function FormInput({
       </div>
 
       {error && (
-        <p className="text-sm text-red-600">{error}</p>
+        <p id={`${inputId}-error`} role="alert" className="text-sm text-red-600">{error}</p>
       )}
+      {description && <div id={`${inputId}-description`}>{description}</div>}
     </div>
   );
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -109,11 +109,18 @@ export default function useAuth() {
       return { success: false, error: loginResult.error };
     } catch (error: any) {
       let message = 'Registration failed';
+      const passwordError = error.response?.status === 400 &&
+        error.response?.data?.error === 'Password validation failed';
 
       if (error.response?.status === 400) {
         const errorMsg = error.response.data?.error || '';
 
-        if (errorMsg.includes('Missing fields')) {
+        if (passwordError) {
+          const details = error.response.data.details;
+          message = Array.isArray(details) && details.length > 0
+            ? details.join(' ')
+            : errorMsg;
+        } else if (errorMsg.includes('Missing fields')) {
           message = 'Please fill in all required fields (username, email, and password)';
         } else if (errorMsg.includes('Password too short')) {
           message = 'Password must be at least 8 characters long';
@@ -129,7 +136,11 @@ export default function useAuth() {
       }
 
       toast.error(message);
-      return { success: false, error: message };
+      return {
+        success: false,
+        error: message,
+        ...(passwordError ? { fieldErrors: { password: message } } : {}),
+      };
     }
   };
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,7 @@ import {
   LoginResponse,
   RegisterRequest,
   RegisterResponse,
+  PasswordValidationRule,
   User,
   AuthError,
   GoogleAuthResponse,
@@ -460,6 +461,14 @@ export const authAPI = {
   
   register: async (userData: RegisterRequest): Promise<RegisterResponse> => {
     const response = await api.post('/auth/register/', userData);
+    return response.data;
+  },
+
+  validatePassword: async (
+    userData: Pick<RegisterRequest, 'username' | 'email' | 'password'>,
+    signal?: AbortSignal,
+  ): Promise<{ rules: PasswordValidationRule[] }> => {
+    const response = await api.post('/auth/password/validate/', userData, { signal });
     return response.data;
   },
   

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -73,6 +73,13 @@ export interface RegisterResponse {
   organization_access_token?: string;
 }
 
+export interface PasswordValidationRule {
+  id: string;
+  help_text: string;
+  valid: boolean | null;
+  errors: string[];
+}
+
 // Google OAuth types
 export interface GoogleAuthResponse {
   message: string;
@@ -115,6 +122,7 @@ export interface ApiResponse<T> {
   success: boolean;
   data?: T;
   error?: string;
+  fieldErrors?: FormValidation;
   statusCode?: number;
   errorCode?: string;
   retry_after_seconds?: number;

--- a/openapi/openapi_spec/auth.openapi.yaml
+++ b/openapi/openapi_spec/auth.openapi.yaml
@@ -57,6 +57,64 @@ components:
           type: string
           example: "Success message"
 paths:
+  /auth/password/validate/:
+    post:
+      summary: Preview the configured registration password requirements
+      description: Checks each existing password validator without creating an account. An empty or omitted password returns requirements with null validity; username and email supply the same similarity context as registration.
+      tags:
+        - Authentication
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  type: string
+                  default: ''
+                  description: Preserved exactly, including surrounding whitespace.
+                username:
+                  type: string
+                  default: ''
+                email:
+                  type: string
+                  default: ''
+                  description: May be incomplete while the registration form is being filled.
+      responses:
+        '200':
+          description: Requirements and individual validation results, including all actual validator messages.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [rules]
+                properties:
+                  rules:
+                    type: array
+                    items:
+                      type: object
+                      required: [id, help_text, valid, errors]
+                      properties:
+                        id:
+                          type: string
+                          description: Configured validator class name.
+                          example: MinimumLengthValidator
+                        help_text:
+                          type: string
+                          example: Your password must contain at least 8 characters.
+                        valid:
+                          type: boolean
+                          nullable: true
+                          description: Null when the password is empty; otherwise whether this rule passed.
+                        errors:
+                          type: array
+                          items:
+                            type: string
+                          example: []
+        '400':
+          description: The request must be an object with string password, username, and email fields when supplied.
   /auth/register/:
     post:
       summary: Register a new user and trigger email verification


### PR DESCRIPTION
Improve registration password feedback so users can see why a password is invalid before submitting.

- Show a concise password requirement summary when the password field is empty.
- Replace the summary with live validation feedback while typing: ❌ with specific error reasons, or ✅ “Password is valid.”
- Refresh validation when the password, username, or email changes.
- Display backend password validation errors beneath the password field if registration fails.
- Reuse the existing Django password validators without adding new password rules. Keep feedback in English.
- Add a password validation endpoint and update the OpenAPI documentation.