### PR TITLE
Feature/med 285 meeting trascript search

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -37,6 +37,7 @@ ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='localhost,127.0.0.1,0.0.0.0').s
     'volar-probankruptcy-orval.ngrok-free.dev',
     'christeen-gawkiest-carmelia.ngrok-free.dev',
     'upload-rinsing-tracing.ngrok-free.dev',
+    'tidiness-confusing-finished.ngrok-free.dev',
 ]
 
 

--- a/backend/meetings/apps.py
+++ b/backend/meetings/apps.py
@@ -5,3 +5,6 @@ class MeetingsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "meetings"
 
+    def ready(self):
+        import meetings.signals  # noqa: F401
+

--- a/backend/meetings/migrations/0021_meeting_transcript_fts.py
+++ b/backend/meetings/migrations/0021_meeting_transcript_fts.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+import django.contrib.postgres.indexes
+import django.contrib.postgres.search
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("meetings", "0020_merge_meeting_slug_audit"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="meeting",
+            name="transcript",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text="Plain-text Zoom transcript for full-text search.",
+            ),
+        ),
+        migrations.AddField(
+            model_name="meeting",
+            name="search_vector",
+            field=django.contrib.postgres.search.SearchVectorField(
+                blank=True, null=True
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="meeting",
+            index=django.contrib.postgres.indexes.GinIndex(
+                fields=["search_vector"], name="mtgs_mtg_search_vec"
+            ),
+        ),
+    ]

--- a/backend/meetings/models.py
+++ b/backend/meetings/models.py
@@ -36,6 +36,8 @@ import uuid
 from core.models import TimeStampedModel
 from meetings.querysets import MeetingManager
 
+from django.contrib.postgres.indexes import GinIndex
+from django.contrib.postgres.search import SearchVectorField
 
 class MeetingTypeDefinition(models.Model):
     """
@@ -159,6 +161,12 @@ class Meeting(SluggedResourceModelMixin, TimeStampedModel):
         default=False,
         help_text="Soft-delete flag (added in migration 0002).",
     )
+    transcript = models.TextField(
+        blank=True,
+        default="",
+        help_text="Plain-text Zoom transcript for full-text search."
+    )
+    search_vector = SearchVectorField(null=True, blank=True)
     minutes_published = models.BooleanField(
         default=False,
         help_text="Whether the meeting minutes have been published to all participants.",
@@ -183,6 +191,10 @@ class Meeting(SluggedResourceModelMixin, TimeStampedModel):
             models.Index(
                 fields=["project", "type_definition"],
                 name="mtgs_mtg_prj_type",
+            ),
+            GinIndex(
+                fields=["search_vector"],
+                name="mtgs_mtg_search_vec",
             ),
         ]
 

--- a/backend/meetings/serializers.py
+++ b/backend/meetings/serializers.py
@@ -442,18 +442,23 @@ class MeetingListSerializer(serializers.ModelSerializer):
         return related_tasks_payload(obj)
 
     def get_search_snippet(self, obj):
-        return (
-            getattr(obj, "transcript_headline", None)
-            or getattr(obj, "summary_headline", None)
-            or ""
-        )
+        transcript_hl = getattr(obj, "transcript_headline", None) or ""
+        summary_hl = getattr(obj, "summary_headline", None) or ""
+        if "<mark>" in transcript_hl:
+            return transcript_hl
+        if "<mark>" in summary_hl:
+            return summary_hl
+        return ""
 
     def get_snippet_source(self, obj):
-        if getattr(obj, "transcript_headline", None):
+        transcript_hl = getattr(obj, "transcript_headline", None) or ""
+        summary_hl = getattr(obj, "summary_headline", None) or ""
+        title_hl = getattr(obj, "title_headline", None) or ""
+        if "<mark>" in transcript_hl:
             return "transcript"
-        if getattr(obj, "summary_headline", None):
+        if "<mark>" in summary_hl:
             return "summary"
-        if getattr(obj, "title_headline", None):
+        if "<mark>" in title_hl:
             return "title"
         return None
 

--- a/backend/meetings/serializers.py
+++ b/backend/meetings/serializers.py
@@ -445,24 +445,24 @@ class MeetingListSerializer(serializers.ModelSerializer):
         title_hl = getattr(obj, "title_headline", None) or ""
         if "<mark>" in title_hl:
             return ""
-        transcript_hl = getattr(obj, "transcript_headline", None) or ""
         summary_hl = getattr(obj, "summary_headline", None) or ""
-        if "<mark>" in transcript_hl:
-            return transcript_hl
+        transcript_hl = getattr(obj, "transcript_headline", None) or ""
         if "<mark>" in summary_hl:
             return summary_hl
+        if "<mark>" in transcript_hl:
+            return transcript_hl
         return ""
 
     def get_snippet_source(self, obj):
         title_hl = getattr(obj, "title_headline", None) or ""
-        transcript_hl = getattr(obj, "transcript_headline", None) or ""
         summary_hl = getattr(obj, "summary_headline", None) or ""
+        transcript_hl = getattr(obj, "transcript_headline", None) or ""
         if "<mark>" in title_hl:
             return "title"
-        if "<mark>" in transcript_hl:
-            return "transcript"
         if "<mark>" in summary_hl:
             return "summary"
+        if "<mark>" in transcript_hl:
+            return "transcript"
         return None
 
 

--- a/backend/meetings/serializers.py
+++ b/backend/meetings/serializers.py
@@ -392,7 +392,8 @@ class MeetingListSerializer(serializers.ModelSerializer):
     generated_tasks_count = serializers.IntegerField(read_only=True, source="task_count")
     generated_decisions = serializers.SerializerMethodField()
     generated_tasks = serializers.SerializerMethodField()
-    transcript_snippet = serializers.SerializerMethodField()
+    search_snippet = serializers.SerializerMethodField()
+    snippet_source = serializers.SerializerMethodField()
     related_decisions = serializers.SerializerMethodField()
     related_tasks = serializers.SerializerMethodField()
 
@@ -418,7 +419,8 @@ class MeetingListSerializer(serializers.ModelSerializer):
             "related_decisions",
             "related_tasks",
             "is_archived",
-            "transcript_snippet",
+            "search_snippet",
+            "snippet_source",
         ]
 
     def get_participants(self, obj):
@@ -439,11 +441,21 @@ class MeetingListSerializer(serializers.ModelSerializer):
     def get_related_tasks(self, obj):
         return related_tasks_payload(obj)
 
-    def get_transcript_snippet(self, obj):
-        transcript = obj.transcript or ""
-        if not transcript:
-            return ""
-        return transcript[:200]
+    def get_search_snippet(self, obj):
+        return (
+            getattr(obj, "transcript_headline", None)
+            or getattr(obj, "summary_headline", None)
+            or ""
+        )
+
+    def get_snippet_source(self, obj):
+        if getattr(obj, "transcript_headline", None):
+            return "transcript"
+        if getattr(obj, "summary_headline", None):
+            return "summary"
+        if getattr(obj, "title_headline", None):
+            return "title"
+        return None
 
 
 class AgendaItemSerializer(serializers.ModelSerializer):

--- a/backend/meetings/serializers.py
+++ b/backend/meetings/serializers.py
@@ -392,6 +392,7 @@ class MeetingListSerializer(serializers.ModelSerializer):
     generated_tasks_count = serializers.IntegerField(read_only=True, source="task_count")
     generated_decisions = serializers.SerializerMethodField()
     generated_tasks = serializers.SerializerMethodField()
+    transcript_snippet = serializers.SerializerMethodField()
     related_decisions = serializers.SerializerMethodField()
     related_tasks = serializers.SerializerMethodField()
 
@@ -417,6 +418,7 @@ class MeetingListSerializer(serializers.ModelSerializer):
             "related_decisions",
             "related_tasks",
             "is_archived",
+            "transcript_snippet",
         ]
 
     def get_participants(self, obj):
@@ -436,6 +438,12 @@ class MeetingListSerializer(serializers.ModelSerializer):
 
     def get_related_tasks(self, obj):
         return related_tasks_payload(obj)
+
+    def get_transcript_snippet(self, obj):
+        transcript = obj.transcript or ""
+        if not transcript:
+            return ""
+        return transcript[:200]
 
 
 class AgendaItemSerializer(serializers.ModelSerializer):

--- a/backend/meetings/serializers.py
+++ b/backend/meetings/serializers.py
@@ -442,6 +442,9 @@ class MeetingListSerializer(serializers.ModelSerializer):
         return related_tasks_payload(obj)
 
     def get_search_snippet(self, obj):
+        title_hl = getattr(obj, "title_headline", None) or ""
+        if "<mark>" in title_hl:
+            return ""
         transcript_hl = getattr(obj, "transcript_headline", None) or ""
         summary_hl = getattr(obj, "summary_headline", None) or ""
         if "<mark>" in transcript_hl:
@@ -451,15 +454,15 @@ class MeetingListSerializer(serializers.ModelSerializer):
         return ""
 
     def get_snippet_source(self, obj):
+        title_hl = getattr(obj, "title_headline", None) or ""
         transcript_hl = getattr(obj, "transcript_headline", None) or ""
         summary_hl = getattr(obj, "summary_headline", None) or ""
-        title_hl = getattr(obj, "title_headline", None) or ""
+        if "<mark>" in title_hl:
+            return "title"
         if "<mark>" in transcript_hl:
             return "transcript"
         if "<mark>" in summary_hl:
             return "summary"
-        if "<mark>" in title_hl:
-            return "title"
         return None
 
 

--- a/backend/meetings/services.py
+++ b/backend/meetings/services.py
@@ -8,6 +8,7 @@ from django.core.cache import cache as django_cache
 logger = logging.getLogger(__name__)
 from django.db import transaction
 from django.db.models import Count, Q
+from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.utils import timezone as dj_timezone
 from django.utils.text import slugify
 
@@ -105,7 +106,12 @@ def apply_meeting_knowledge_filters(qs, filters: dict):
 
     q = filters.get("q")
     if q:
-        qs = qs.filter(Q(title__icontains=q) | Q(summary__icontains=q))
+        search_query = SearchQuery(q)
+        qs = (
+            qs.filter(search_vector=search_query)
+            .annotate(rank=SearchRank("search_vector", search_query))
+            .order_by("-rank")
+        )
 
     mt = filters.get("meeting_type")
     if mt:

--- a/backend/meetings/signals.py
+++ b/backend/meetings/signals.py
@@ -1,0 +1,9 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+
+@receiver(post_save, sender="meetings.Meeting")
+def update_search_vector_on_save(sender, instance, **kwargs):
+    """Keep search_vector in sync whenever a Meeting is created or updated."""
+    from meetings.tasks import update_meeting_search_vector
+    update_meeting_search_vector.delay(instance.pk)  # type: ignore[operator]

--- a/backend/meetings/tasks.py
+++ b/backend/meetings/tasks.py
@@ -1,0 +1,22 @@
+import logging
+
+from celery import shared_task
+from django.contrib.postgres.search import SearchVector
+
+logger = logging.getLogger(__name__)
+
+@shared_task(bind=True, ignore_result=True)
+def update_meeting_search_vector(self, meeting_id: int) -> None:
+    """Update the search_vector field for a meeting after transcript is saved"""
+    from meetings.models import Meeting
+
+    updated = Meeting.objects.filter(pk=meeting_id).update(
+        search_vector=SearchVector("title", weight="A")
+        + SearchVector("summary", weight="B")
+        + SearchVector("transcript", weight="C"),
+    )
+
+    if not updated:
+        logger.warning("update_meeting_search_vector: meeting_id=%s not found", meeting_id)
+    else:
+        logger.info("update_meeting_search_vector: updated meeting_id=%s", meeting_id)

--- a/backend/meetings/tests/test_transcript_search.py
+++ b/backend/meetings/tests/test_transcript_search.py
@@ -120,7 +120,7 @@ class TestTranscriptSearch(TestCase):
         self.assertIn(my_meeting.pk, result_ids)
         self.assertNotIn(other_meeting.pk, result_ids)
 
-    def test_api_returns_transcript_snippet(self):
+    def test_api_returns_search_snippet_with_highlight(self):
         client = APIClient()
         client.force_authenticate(user=self.user)
 
@@ -131,12 +131,13 @@ class TestTranscriptSearch(TestCase):
             objective="o",
             transcript="Tim: We need to cut the budget. " * 20,
         )
+        update_meeting_search_vector(meeting.pk)
 
-        url = f"/api/projects/{self.project.slug}/meetings/"
+        url = f"/api/projects/{self.project.slug}/meetings/?q=budget"
         response = client.get(url)
 
         self.assertEqual(response.status_code, 200)
         result = next(r for r in response.data["results"] if r["id"] == meeting.id)
-        self.assertIn("transcript_snippet", result)
-        self.assertLessEqual(len(result["transcript_snippet"]), 200)
-        self.assertTrue(result["transcript_snippet"].startswith("Tim:"))
+        self.assertIn("search_snippet", result)
+        self.assertIn("<mark>", result["search_snippet"])
+        self.assertIn("budget", result["search_snippet"])

--- a/backend/meetings/tests/test_transcript_search.py
+++ b/backend/meetings/tests/test_transcript_search.py
@@ -126,7 +126,7 @@ class TestTranscriptSearch(TestCase):
 
         meeting = Meeting.objects.create(
             project=self.project,
-            title="Budget Meeting",
+            title="Weekly Sync",
             type_definition=self.meeting_type,
             objective="o",
             transcript="Tim: We need to cut the budget. " * 20,
@@ -197,6 +197,46 @@ class TestTranscriptSearch(TestCase):
         result = next(r for r in response.data["results"] if r["id"] == meeting.id)
         self.assertEqual(result["snippet_source"], "title")
         self.assertEqual(result["search_snippet"], "")
+
+    def test_snippet_source_priority_title_over_summary_and_transcript(self):
+        """When title, summary, and transcript all match, title takes priority."""
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        meeting = Meeting.objects.create(
+            project=self.project,
+            title="Budget Review Session",
+            type_definition=self.meeting_type,
+            objective="o",
+            summary="We discussed the quarterly budget allocation.",
+            transcript="Tim: The budget needs to be reviewed carefully.",
+        )
+        update_meeting_search_vector(meeting.pk)
+
+        response = client.get(f"/api/projects/{self.project.slug}/meetings/?q=budget")
+        result = next(r for r in response.data["results"] if r["id"] == meeting.id)
+        self.assertEqual(result["snippet_source"], "title")
+        self.assertEqual(result["search_snippet"], "")
+
+    def test_snippet_source_priority_summary_over_transcript(self):
+        """When summary and transcript both match but title does not, summary takes priority."""
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        meeting = Meeting.objects.create(
+            project=self.project,
+            title="Weekly Sync",
+            type_definition=self.meeting_type,
+            objective="o",
+            summary="We discussed the quarterly budget allocation.",
+            transcript="Tim: The budget needs to be reviewed carefully.",
+        )
+        update_meeting_search_vector(meeting.pk)
+
+        response = client.get(f"/api/projects/{self.project.slug}/meetings/?q=budget")
+        result = next(r for r in response.data["results"] if r["id"] == meeting.id)
+        self.assertEqual(result["snippet_source"], "summary")
+        self.assertIn("<mark>", result["search_snippet"])
 
     def test_snippet_source_is_null_when_no_search_query(self):
         client = APIClient()

--- a/backend/meetings/tests/test_transcript_search.py
+++ b/backend/meetings/tests/test_transcript_search.py
@@ -32,6 +32,26 @@ class TestTranscriptSearch(TestCase):
             label="Weekly"
         )
 
+    def test_search_vector_updated_on_meeting_save(self):
+        """Creating a meeting should make it immediately searchable by title and summary."""
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        meeting = Meeting.objects.create(
+            project=self.project,
+            title="Quarterly Budget Review",
+            type_definition=self.meeting_type,
+            objective="o",
+            summary="We discussed the quarterly budget allocation in detail.",
+        )
+        # signal fires .delay() — call the task synchronously to simulate Celery executing it
+        update_meeting_search_vector(meeting.pk)
+
+        response = client.get(f"/api/projects/{self.project.slug}/meetings/?q=quarterly")
+        self.assertEqual(response.status_code, 200)
+        returned_ids = [r["id"] for r in response.data["results"]]
+        self.assertIn(meeting.id, returned_ids)
+
     def test_task_populates_search_vector(self):
         meeting = Meeting.objects.create(
             project=self.project,

--- a/backend/meetings/tests/test_transcript_search.py
+++ b/backend/meetings/tests/test_transcript_search.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from rest_framework.test import APIClient
 
 from core.models import Organization, Project, ProjectMember, CustomUser
 from meetings.models import Meeting, MeetingTypeDefinition
@@ -118,3 +119,24 @@ class TestTranscriptSearch(TestCase):
         result_ids = [m.pk for m in results]
         self.assertIn(my_meeting.pk, result_ids)
         self.assertNotIn(other_meeting.pk, result_ids)
+
+    def test_api_returns_transcript_snippet(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        meeting = Meeting.objects.create(
+            project=self.project,
+            title="Budget Meeting",
+            type_definition=self.meeting_type,
+            objective="o",
+            transcript="Tim: We need to cut the budget. " * 20,
+        )
+
+        url = f"/api/projects/{self.project.slug}/meetings/"
+        response = client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        result = next(r for r in response.data["results"] if r["id"] == meeting.id)
+        self.assertIn("transcript_snippet", result)
+        self.assertLessEqual(len(result["transcript_snippet"]), 200)
+        self.assertTrue(result["transcript_snippet"].startswith("Tim:"))

--- a/backend/meetings/tests/test_transcript_search.py
+++ b/backend/meetings/tests/test_transcript_search.py
@@ -176,7 +176,8 @@ class TestTranscriptSearch(TestCase):
         response = client.get(f"/api/projects/{self.project.slug}/meetings/?q=budget")
         result = next(r for r in response.data["results"] if r["id"] == meeting.id)
         self.assertEqual(result["snippet_source"], "summary")
-        self.assertEqual(result["search_snippet"], "")
+        self.assertIn("<mark>", result["search_snippet"])
+        self.assertIn("budget", result["search_snippet"])
 
     def test_snippet_source_is_title_when_matched_in_title(self):
         client = APIClient()

--- a/backend/meetings/tests/test_transcript_search.py
+++ b/backend/meetings/tests/test_transcript_search.py
@@ -254,3 +254,60 @@ class TestTranscriptSearch(TestCase):
         result = next(r for r in response.data["results"] if r["id"] == meeting.id)
         self.assertIsNone(result["snippet_source"])
         self.assertEqual(result["search_snippet"], "")
+
+    def test_api_cannot_see_meetings_from_another_project_in_same_org(self):
+        """Meetings from another project in the same org must not appear in search results."""
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+        )
+        other_type = MeetingTypeDefinition.objects.create(
+            project=other_project,
+            slug="weekly",
+            label="Weekly",
+        )
+        other_meeting = Meeting.objects.create(
+            project=other_project,
+            title="Budget Sync",
+            type_definition=other_type,
+            objective="o",
+            transcript="Sarah: let us review the budget.",
+        )
+        update_meeting_search_vector(other_meeting.pk)
+
+        response = client.get(f"/api/projects/{self.project.slug}/meetings/?q=budget")
+        self.assertEqual(response.status_code, 200)
+        returned_ids = [r["id"] for r in response.data["results"]]
+        self.assertNotIn(other_meeting.id, returned_ids)
+
+    def test_api_cannot_see_meetings_from_another_organization(self):
+        """Meetings from a completely different org must not appear in search results."""
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        other_org = Organization.objects.create(name="Other Org", slug="other-org")
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=other_org,
+        )
+        other_type = MeetingTypeDefinition.objects.create(
+            project=other_project,
+            slug="weekly",
+            label="Weekly",
+        )
+        other_meeting = Meeting.objects.create(
+            project=other_project,
+            title="Budget Planning",
+            type_definition=other_type,
+            objective="o",
+            transcript="Alice: we must plan the budget carefully.",
+        )
+        update_meeting_search_vector(other_meeting.pk)
+
+        response = client.get(f"/api/projects/{self.project.slug}/meetings/?q=budget")
+        self.assertEqual(response.status_code, 200)
+        returned_ids = [r["id"] for r in response.data["results"]]
+        self.assertNotIn(other_meeting.id, returned_ids)

--- a/backend/meetings/tests/test_transcript_search.py
+++ b/backend/meetings/tests/test_transcript_search.py
@@ -1,0 +1,120 @@
+from django.test import TestCase
+
+from core.models import Organization, Project, ProjectMember, CustomUser
+from meetings.models import Meeting, MeetingTypeDefinition
+from meetings.services import apply_meeting_knowledge_filters
+from meetings.tasks import update_meeting_search_vector
+
+class TestTranscriptSearch(TestCase):
+    """Full-text search across meeting transcripts."""
+    def setUp(self):
+        self.organization = Organization.objects.create(
+            name="Test Org", slug="test-org"
+        )
+        self.project = Project.objects.create(
+            name="Test Project",
+            organization=self.organization,
+        )
+        self.user = CustomUser.objects.create_user(
+            email="user@example.com",
+            password="password",
+            username="testuser"
+        )
+        ProjectMember.objects.create(
+            user=self.user,
+            project=self.project,
+            is_active=True
+        )
+        self.meeting_type = MeetingTypeDefinition.objects.create(
+            project=self.project,
+            slug="weekly",
+            label="Weekly"
+        )
+
+    def test_task_populates_search_vector(self):
+        meeting = Meeting.objects.create(
+            project=self.project,
+            title="Budget Review",
+            type_definition=self.meeting_type,
+            objective="Review Q3 Budget",
+            transcript="Tim: we need to cut the budget. Sarah: I agree."
+        )
+        self.assertIsNone(meeting.search_vector)
+
+        update_meeting_search_vector(meeting.pk)
+
+        meeting.refresh_from_db()
+        self.assertIsNotNone(meeting.search_vector)
+
+    def test_task_missing_meeting_does_not_raise(self):
+        try:
+            update_meeting_search_vector(99999)
+        except Exception as e:
+            self.fail(f"Task raised an unexpected exception: {e}")
+
+    def test_search_finds_transcript_content(self):
+        Meeting.objects.create(
+            project=self.project,
+            title="Weekly Sync",
+            type_definition=self.meeting_type,
+            objective="o",
+            transcript="Tim: We need to cut the budget. Sarah: I agree.",
+        )
+
+        update_meeting_search_vector(
+            Meeting.objects.get(project=self.project).pk
+        )
+
+        qs = Meeting.objects.filter(project=self.project)
+        results = apply_meeting_knowledge_filters(qs, {"q": "budget"})
+        self.assertIn(
+            Meeting.objects.get(project=self.project).pk,
+            [m.pk for m in results],
+        )
+
+    def test_search_no_match_returns_empty(self):
+        meeting = Meeting.objects.create(
+            project=self.project,
+            title="Weekly Sync",
+            type_definition=self.meeting_type,
+            objective="o",
+            transcript="Tim: We need to cut the budget. Sarah: I agree.",
+        )
+        update_meeting_search_vector(meeting.pk)
+
+        qs = Meeting.objects.filter(project=self.project)
+        results = apply_meeting_knowledge_filters(qs, {"q": "blockchain"})
+        self.assertEqual(results.count(), 0)
+
+    def test_search_scoped_to_project(self):
+        other_project = Project.objects.create(
+            name="Other Project",
+            organization=self.organization,
+        )
+        other_type = MeetingTypeDefinition.objects.create(
+            project=other_project,
+            slug="weekly",
+            label="Weekly",
+        )
+        my_meeting = Meeting.objects.create(
+            project=self.project,
+            title="My Meeting",
+            type_definition=self.meeting_type,
+            objective="o",
+            transcript="Tim: discuss the budget allocation.",
+        )
+        other_meeting = Meeting.objects.create(
+            project=other_project,
+            title="Other Meeting",
+            type_definition=other_type,
+            objective="o",
+            transcript="Sarah: discuss the budget allocation.",
+        )
+        update_meeting_search_vector(my_meeting.pk)
+        update_meeting_search_vector(other_meeting.pk)
+
+        qs = Meeting.objects.filter(project=self.project)
+        results = apply_meeting_knowledge_filters(qs, {"q": "budget"})
+        result_ids = [m.pk for m in results]
+        self.assertIn(my_meeting.pk, result_ids)
+        self.assertNotIn(other_meeting.pk, result_ids)

--- a/backend/meetings/tests/test_transcript_search.py
+++ b/backend/meetings/tests/test_transcript_search.py
@@ -141,3 +141,75 @@ class TestTranscriptSearch(TestCase):
         self.assertIn("search_snippet", result)
         self.assertIn("<mark>", result["search_snippet"])
         self.assertIn("budget", result["search_snippet"])
+
+    def test_snippet_source_is_transcript_when_matched_in_transcript(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        meeting = Meeting.objects.create(
+            project=self.project,
+            title="Weekly Sync",
+            type_definition=self.meeting_type,
+            objective="o",
+            transcript="Tim: We need to cut the budget allocation.",
+        )
+        update_meeting_search_vector(meeting.pk)
+
+        response = client.get(f"/api/projects/{self.project.slug}/meetings/?q=budget")
+        result = next(r for r in response.data["results"] if r["id"] == meeting.id)
+        self.assertEqual(result["snippet_source"], "transcript")
+
+    def test_snippet_source_is_summary_when_matched_in_summary(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        meeting = Meeting.objects.create(
+            project=self.project,
+            title="Weekly Sync",
+            type_definition=self.meeting_type,
+            objective="o",
+            summary="We discussed the quarterly budget allocation.",
+            transcript="",
+        )
+        update_meeting_search_vector(meeting.pk)
+
+        response = client.get(f"/api/projects/{self.project.slug}/meetings/?q=budget")
+        result = next(r for r in response.data["results"] if r["id"] == meeting.id)
+        self.assertEqual(result["snippet_source"], "summary")
+        self.assertEqual(result["search_snippet"], "")
+
+    def test_snippet_source_is_title_when_matched_in_title(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        meeting = Meeting.objects.create(
+            project=self.project,
+            title="Budget Planning Session",
+            type_definition=self.meeting_type,
+            objective="o",
+            summary="",
+            transcript="",
+        )
+        update_meeting_search_vector(meeting.pk)
+
+        response = client.get(f"/api/projects/{self.project.slug}/meetings/?q=budget")
+        result = next(r for r in response.data["results"] if r["id"] == meeting.id)
+        self.assertEqual(result["snippet_source"], "title")
+        self.assertEqual(result["search_snippet"], "")
+
+    def test_snippet_source_is_null_when_no_search_query(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        meeting = Meeting.objects.create(
+            project=self.project,
+            title="Weekly Sync",
+            type_definition=self.meeting_type,
+            objective="o",
+            transcript="Tim: We need to cut the budget.",
+        )
+
+        response = client.get(f"/api/projects/{self.project.slug}/meetings/")
+        result = next(r for r in response.data["results"] if r["id"] == meeting.id)
+        self.assertIsNone(result["snippet_source"])
+        self.assertEqual(result["search_snippet"], "")

--- a/backend/meetings/views.py
+++ b/backend/meetings/views.py
@@ -199,6 +199,37 @@ class MeetingViewSet(SlugLookupViewSetMixin, viewsets.ModelViewSet):
 
         qs_filtered = apply_meeting_knowledge_filters(qs_base, filters).distinct()
 
+        q = filters.get("q", "").strip()
+        if q:
+            from django.contrib.postgres.search import SearchHeadline, SearchQuery
+            sq = SearchQuery(q)
+            qs_filtered = qs_filtered.annotate(
+                transcript_headline=SearchHeadline(
+                    "transcript", sq,
+                    start_sel="<mark>",
+                    stop_sel="</mark>",
+                    max_words=15,
+                    min_words=5,
+                    max_fragments=1,
+                ),
+                summary_headline=SearchHeadline(
+                    "summary", sq,
+                    start_sel="<mark>",
+                    stop_sel="</mark>",
+                    max_words=15,
+                    min_words=5,
+                    max_fragments=1,
+                ),
+                title_headline=SearchHeadline(
+                    "title", sq,
+                    start_sel="<mark>",
+                    stop_sel="</mark>",
+                    max_words=15,
+                    min_words=5,
+                    max_fragments=1,
+                ),
+            )
+
         ordering = filters.get("ordering") or "-created_at"
         qs = qs_filtered.order_by(*meeting_list_order_by_fields(ordering))
 

--- a/backend/zoom_integration/services.py
+++ b/backend/zoom_integration/services.py
@@ -598,6 +598,56 @@ def _sync_layer3_summary(row: ZoomMeetingData, webhook_uuid: str) -> None:
     )
 
 
+def _parse_vtt_to_text(vtt: str) -> str:
+    """Strip VTT timestamps and metadata, return plain transcript text."""
+    lines = []
+    for line in vtt.splitlines():
+        line = line.strip()
+        if not line or line == "WEBVTT" or "-->" in line or line.isdigit():
+            continue
+        lines.append(line)
+
+    return " ".join(lines)
+
+def _sync_layer3_transcript(row: ZoomMeetingData, webhook_uuid: str) -> None:
+    """Layer 3 (transcript event): download VTT transcript and store on Meeting."""
+    del webhook_uuid
+    user = row.zoom_host_user
+    if not user:
+        raise ValueError("ZoomMeetingData has no zoom_host_user.")
+    mid = (row.zoom_meeting_id or "").strip()
+    if not mid:
+        raise ValueError("Missing zoom_meeting_id for transcript.")
+
+    credential = get_valid_credential(user=user)
+    data = zoom_api_get(user=user, path=f"/meetings/{mid}/recordings")
+
+    transcript_text = ""
+    for f in data.get("recording_files") or []:
+        if not isinstance(f, dict):
+            continue
+        if f.get("file_type") == "TRANSCRIPT":
+            download_url = f.get("download_url")
+
+            if not download_url:
+                continue
+
+            resp = requests.get(
+                download_url,
+                headers={"Authorization": f"Bearer {credential.get_access_token()}"},
+                timeout=60
+            )
+
+            resp.raise_for_status()
+            transcript_text = _parse_vtt_to_text(resp.text)
+            break
+
+    if transcript_text:
+        with transaction.atomic():
+            meeting = row.meeting
+            meeting.transcript = transcript_text
+            meeting.save(update_fields=["transcript"])
+
 def sync_zoom_meeting_for_event(
     zoom_meeting_data_id: int,
     event_type: str,
@@ -619,6 +669,7 @@ def sync_zoom_meeting_for_event(
         _sync_layer3_summary(row, webhook_uuid)
     elif et == EVENT_TRANSCRIPT_COMPLETED:
         _sync_layer3_participants(row, webhook_uuid)
+        _sync_layer3_transcript(row, webhook_uuid)
     else:
         logging.getLogger(__name__).info(
             "zoom sync: ignored event_type=%s zoom_meeting_data_id=%s",

--- a/backend/zoom_integration/services.py
+++ b/backend/zoom_integration/services.py
@@ -669,7 +669,8 @@ def sync_zoom_meeting_for_event(
         _sync_layer3_summary(row, webhook_uuid)
     elif et == EVENT_TRANSCRIPT_COMPLETED:
         _sync_layer3_participants(row, webhook_uuid)
-        _sync_layer3_transcript(row, webhook_uuid)
+        from zoom_integration.tasks import sync_meeting_transcript
+        sync_meeting_transcript.delay(zoom_meeting_data_id) # type: ignore[operator]
     else:
         logging.getLogger(__name__).info(
             "zoom sync: ignored event_type=%s zoom_meeting_data_id=%s",

--- a/backend/zoom_integration/tasks.py
+++ b/backend/zoom_integration/tasks.py
@@ -77,9 +77,10 @@ def process_zoom_webhook_event(
 
 @shared_task(bind=True, ignore_result=True)
 def sync_meeting_transcript(self, zoom_meeting_data_id: int) -> None:
-    """Download and store Zoom transcript for a meeting, then trigger search vector update."""
-    from meetings.tasks import update_meeting_search_vector
+    """Download and store Zoom transcript for a meeting.
 
+    The post_save signal on Meeting automatically updates search_vector after save.
+    """
     if not ZoomMeetingData.objects.filter(pk=zoom_meeting_data_id).exists():
         logger.warning("sync_meeting_transcript: ZoomMeetingData missing id=%s", zoom_meeting_data_id)
         return
@@ -93,7 +94,3 @@ def sync_meeting_transcript(self, zoom_meeting_data_id: int) -> None:
             "sync_meeting_transcript: failed zoom_meeting_data_id=%s",
             zoom_meeting_data_id
         )
-        return
-
-    if row.meeting_id:
-        update_meeting_search_vector.delay(row.meeting_id) # type: ignore[operator]

--- a/backend/zoom_integration/tasks.py
+++ b/backend/zoom_integration/tasks.py
@@ -9,7 +9,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from .models import ZoomMeetingData
-from .services import ZOOM_SYNC_EVENT_TYPES, sync_zoom_meeting_for_event
+from .services import ZOOM_SYNC_EVENT_TYPES, sync_zoom_meeting_for_event, _sync_layer3_transcript
 
 logger = logging.getLogger(__name__)
 
@@ -74,3 +74,26 @@ def process_zoom_webhook_event(
                 "zoom webhook task: failed to persist sync error id=%s",
                 zoom_meeting_data_id,
             )
+
+@shared_task(bind=True, ignore_result=True)
+def sync_meeting_transcript(self, zoom_meeting_data_id: int) -> None:
+    """Download and store Zoom transcript for a meeting, then trigger search vector update."""
+    from meetings.tasks import update_meeting_search_vector
+
+    if not ZoomMeetingData.objects.filter(pk=zoom_meeting_data_id).exists():
+        logger.warning("sync_meeting_transcript: ZoomMeetingData missing id=%s", zoom_meeting_data_id)
+        return
+
+    row = ZoomMeetingData.objects.select_related("zoom_host_user").get(pk=zoom_meeting_data_id)
+
+    try:
+        _sync_layer3_transcript(row, "")
+    except Exception:
+        logger.exception(
+            "sync_meeting_transcript: failed zoom_meeting_data_id=%s",
+            zoom_meeting_data_id
+        )
+        return
+
+    if row.meeting_id:
+        update_meeting_search_vector.delay(row.meeting_id) # type: ignore[operator]

--- a/backend/zoom_integration/tests.py
+++ b/backend/zoom_integration/tests.py
@@ -1321,3 +1321,30 @@ class ZoomSyncStepDTest(TestCase):
         payload = build_zoom_post_meeting_payload(self.zd)
         self.assertEqual(payload["summary_text"], "")
         self.assertEqual(payload["user_feedback_code"], "not_applicable")
+
+from zoom_integration.services import _parse_vtt_to_text
+
+class PraseVttToTextTests(TestCase):
+    def test_strips_timestamps_and_header(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "1\n"
+            "00:00:01.000 --> 00:00:04.000\n"
+            "Tim: We need to cut the budget.\n\n"
+            "2\n"
+            "00:00:05.000 --> 00:00:08.000\n"
+            "Sarah: I agree.\n"
+        )
+        result = _parse_vtt_to_text(vtt)
+        self.assertIn("Tim: We need to cut the budget.", result)
+        self.assertIn("Sarah: I agree.", result)
+        self.assertNotIn("WEBVTT", result)
+
+    def test_empty_vtt_returns_empty_string(self):
+        self.assertEqual(_parse_vtt_to_text(""), "")
+
+# @patch("zoom_integration.services.request.get")
+# def test_transcript_completed_stores_text_on_meeting(self, mock_get):
+#     recordings_response = self._json_response({
+#         reco
+#     })

--- a/frontend/src/app/(project)/meetings/page.tsx
+++ b/frontend/src/app/(project)/meetings/page.tsx
@@ -205,6 +205,7 @@ export default function MeetingsV2Page() {
               onCompletedSortChange={setCompletedSort}
               projectId={projectId}
               onCreate={() => setCreateOpen(true)}
+              searchQuery={debouncedSearch}
             />
           )}
 

--- a/frontend/src/components/meetings/MeetingCard.tsx
+++ b/frontend/src/components/meetings/MeetingCard.tsx
@@ -1,14 +1,32 @@
 'use client';
 
+import React from 'react';
 import Link from 'next/link';
 import { useBuildUrl } from '@/lib/buildUrl';
 import { CalendarDays, FileText, ListChecks, Users } from 'lucide-react';
 import type { MeetingListItem } from '@/types/meeting';
 import MeetingStatusPill from './MeetingStatusPill';
 
+const SNIPPET_SOURCE_LABEL: Record<string, string> = {
+  transcript: 'Transcript',
+  summary: 'Summary',
+};
+
+function highlightTitle(title: string, query?: string): React.ReactNode {
+  if (!query?.trim()) return title;
+  const regex = new RegExp(`(${query.trim()})`, 'gi');
+  const parts = title.split(regex);
+  return parts.map((part, i) =>
+    regex.test(part)
+      ? <mark key={i} className="rounded bg-yellow-100 px-0.5 font-semibold text-yellow-800">{part}</mark>
+      : part
+  );
+}
+
 interface Props {
   meeting: MeetingListItem;
   projectId: number | string;
+  searchQuery?: string;
 }
 
 function formatScheduled(dateIso: string | null): string {
@@ -22,7 +40,7 @@ function formatScheduled(dateIso: string | null): string {
   });
 }
 
-export default function MeetingCard({ meeting, projectId }: Props) {
+export default function MeetingCard({ meeting, projectId, searchQuery }: Props) {
   const buildUrl = useBuildUrl();
   const decisions =
     meeting.generated_decisions_count ?? meeting.decision_count ?? 0;
@@ -39,7 +57,7 @@ export default function MeetingCard({ meeting, projectId }: Props) {
     >
       <div className="flex items-start justify-between gap-3">
         <h3 className="line-clamp-1 text-[15px] font-semibold text-gray-900">
-          {meeting.title || 'Untitled meeting'}
+          {highlightTitle(meeting.title || 'Untitled meeting', meeting.snippet_source === 'title' ? searchQuery : undefined)}
         </h3>
         <MeetingStatusPill status={meeting.status} />
       </div>
@@ -82,6 +100,22 @@ export default function MeetingCard({ meeting, projectId }: Props) {
           <span className="italic text-gray-400">· archived</span>
         )}
       </div>
+
+      {searchQuery && meeting.search_snippet && meeting.snippet_source !== 'title' && (
+        <div className="mt-2 border-t border-gray-50 pt-2">
+          {meeting.snippet_source && SNIPPET_SOURCE_LABEL[meeting.snippet_source] && (
+            <span className="mb-1 inline-block text-[10px] font-medium uppercase tracking-wide text-gray-400">
+              {SNIPPET_SOURCE_LABEL[meeting.snippet_source]}
+            </span>
+          )}
+          <p
+            className="line-clamp-2 text-xs text-gray-500 [&_mark]:rounded [&_mark]:bg-yellow-100 [&_mark]:px-0.5 [&_mark]:font-semibold [&_mark]:text-yellow-800"
+            // search_snippet contains only <mark> tags from PostgreSQL SearchHeadline — safe
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: meeting.search_snippet }}
+          />
+        </div>
+      )}
     </Link>
   );
 }

--- a/frontend/src/components/meetings/MeetingColumn.tsx
+++ b/frontend/src/components/meetings/MeetingColumn.tsx
@@ -21,6 +21,7 @@ interface Props {
   onSortChange: (key: MeetingSortKey) => void;
   projectId: number | string;
   onCreate?: () => void;
+  searchQuery?: string;
 }
 
 function SortMenu({
@@ -99,6 +100,7 @@ export default function MeetingColumn({
   onSortChange,
   projectId,
   onCreate,
+  searchQuery,
 }: Props) {
   const sorted = applyMeetingSort(meetings, sortKey);
   const hasRows = sorted.length > 0;
@@ -125,7 +127,7 @@ export default function MeetingColumn({
         <ul className="flex flex-col gap-2.5">
           {sorted.map((m) => (
             <li key={m.id}>
-              <MeetingCard meeting={m} projectId={projectId} />
+              <MeetingCard meeting={m} projectId={projectId} searchQuery={searchQuery} />
             </li>
           ))}
         </ul>

--- a/frontend/src/components/meetings/MeetingsFilterBar.tsx
+++ b/frontend/src/components/meetings/MeetingsFilterBar.tsx
@@ -68,8 +68,8 @@ export default function MeetingsFilterBar({
             type="search"
             value={search}
             onChange={(e) => onSearchChange(e.target.value)}
-            placeholder="Search meetings…"
-            aria-label="Search meetings"
+            placeholder="Search titles, summaries & transcripts…"
+            aria-label="Search titles, summaries and transcripts"
             className="w-full rounded-md border border-gray-200 bg-white py-1.5 pl-8 pr-3 text-sm text-gray-900 outline-none transition placeholder:text-gray-400 focus:border-[#3CCED7] focus:ring-2 focus:ring-[#3CCED7]/30"
           />
         </div>

--- a/frontend/src/components/meetings/MeetingsHubColumns.tsx
+++ b/frontend/src/components/meetings/MeetingsHubColumns.tsx
@@ -17,6 +17,7 @@ interface Props {
   onCompletedSortChange: (key: MeetingSortKey) => void;
   projectId: number | string;
   onCreate: () => void;
+  searchQuery?: string;
 }
 
 export default function MeetingsHubColumns({
@@ -32,6 +33,7 @@ export default function MeetingsHubColumns({
   onCompletedSortChange,
   projectId,
   onCreate,
+  searchQuery,
 }: Props) {
   return (
     <div className="grid grid-cols-1 gap-5 lg:grid-cols-2 lg:items-start">
@@ -45,6 +47,7 @@ export default function MeetingsHubColumns({
         onSortChange={onIncomingSortChange}
         projectId={projectId}
         onCreate={onCreate}
+        searchQuery={searchQuery}
       />
       <MeetingColumn
         title="Completed meetings"
@@ -55,6 +58,7 @@ export default function MeetingsHubColumns({
         sortKey={completedSort}
         onSortChange={onCompletedSortChange}
         projectId={projectId}
+        searchQuery={searchQuery}
       />
     </div>
   );

--- a/frontend/src/components/meetings/discovery/MeetingDiscoveryToolbar.tsx
+++ b/frontend/src/components/meetings/discovery/MeetingDiscoveryToolbar.tsx
@@ -92,7 +92,7 @@ function MeetingToolbarSearch({
         type="text"
         inputMode="search"
         autoComplete="off"
-        placeholder="Search meetings…"
+        placeholder="Search titles, summaries & transcripts…"
         value={local}
         onChange={(e) => setLocal(e.target.value)}
         disabled={disabled}

--- a/frontend/src/lib/api/meetingsApi.ts
+++ b/frontend/src/lib/api/meetingsApi.ts
@@ -276,6 +276,10 @@ function normalizeMeetingListItem(raw: Record<string, unknown>): MeetingListItem
     related_tasks: normalizeKnowledgeLinks(raw.related_tasks ?? raw.relatedTasks),
     is_archived: Boolean(raw.is_archived),
     status: typeof raw.status === 'string' ? raw.status as MeetingStatus : 'draft',
+    search_snippet: typeof raw.search_snippet === 'string' ? raw.search_snippet : undefined,
+    snippet_source: (raw.snippet_source === 'transcript' || raw.snippet_source === 'summary' || raw.snippet_source === 'title')
+      ? raw.snippet_source
+      : undefined,
   };
 }
 

--- a/frontend/src/types/meeting.ts
+++ b/frontend/src/types/meeting.ts
@@ -159,7 +159,8 @@ export interface MeetingListItem {
   related_decisions: KnowledgeNavigationLink[];
   related_tasks: KnowledgeNavigationLink[];
   is_archived: boolean;
-  transcript_snippet?: string;
+  search_snippet?: string;
+  snippet_source?: 'transcript' | 'summary' | 'title' | null;
 }
 
 export interface PaginatedMeetingsList {

--- a/frontend/src/types/meeting.ts
+++ b/frontend/src/types/meeting.ts
@@ -159,6 +159,7 @@ export interface MeetingListItem {
   related_decisions: KnowledgeNavigationLink[];
   related_tasks: KnowledgeNavigationLink[];
   is_archived: boolean;
+  transcript_snippet?: string;
 }
 
 export interface PaginatedMeetingsList {


### PR DESCRIPTION
## MED-285: Meeting Transcript Search

### Summary

- Adds a `transcript` text field to the `Meeting` model and stores plain-text Zoom VTT transcripts on ingest via `_sync_layer3_transcript`.
- Introduces a PostgreSQL full-text search index (`GinIndex` on `search_vector`) combining title (weight A), summary (weight B), and transcript (weight C).
- A Celery task (`update_meeting_search_vector`) rebuilds the index on demand; a `post_save` signal fires it automatically on every Meeting save, so meetings are searchable immediately on creation and after transcript ingest — no webhook required.
- The list endpoint annotates results with `SearchHeadline` snippets for all three fields and returns `search_snippet` + `snippet_source` (priority: title → summary → transcript) so the frontend can highlight the match source.
- Search is scoped to the requesting user's accessible meetings within their project; cross-project and cross-org results are never returned.
- Updates the search bar placeholder to "Search titles, summaries & transcripts…" in both `MeetingsFilterBar` and `MeetingDiscoveryToolbar`.

### Changes

**Backend**
- `meetings/models.py` — adds `transcript` TextField and `search_vector` SearchVectorField with GinIndex
- `meetings/migrations/0021_meeting_transcript_fts.py` — migration for transcript field, search_vector field, and GIN index
- `meetings/tasks.py` — `update_meeting_search_vector` Celery task that rebuilds weighted SearchVector (title/summary/transcript)
- `meetings/signals.py` *(new)* — `post_save` signal that triggers `update_meeting_search_vector.delay()` on every Meeting save
- `meetings/apps.py` — registers signals in `ready()`
- `meetings/serializers.py` — `get_search_snippet` and `get_snippet_source` methods that check `<mark>` tags in annotated headlines and apply title → summary → transcript priority
- `meetings/views.py` — `MeetingViewSet.list()` annotates queryset with `SearchHeadline` for all three fields when `q` param is present
- `zoom_integration/services.py` — `_sync_layer3_transcript` stores parsed VTT text into `meeting.transcript`; the subsequent `meeting.save()` triggers the post_save signal, keeping search_vector in sync automatically

**Frontend**
- `frontend/src/components/meetings/MeetingsFilterBar.tsx` — placeholder updated to "Search titles, summaries & transcripts…"
- `frontend/src/components/meetings/discovery/MeetingDiscoveryToolbar.tsx` — placeholder updated, debounced search input (320ms)
- `frontend/src/lib/api/meetingsApi.ts` — `normalizeMeetingListItem` maps `search_snippet` and `snippet_source` from API response; `buildMeetingListParams` includes `q` param

**Tests**
- `meetings/tests/test_transcript_search.py` — 15 pytest tests covering:
  - `test_search_vector_updated_on_meeting_save` — immediate searchability after save
  - `test_task_populates_search_vector` — task sets the search_vector field
  - `test_task_missing_meeting_does_not_raise` — graceful handling of missing meetings
  - `test_search_finds_transcript_content` — transcript text is searchable
  - `test_search_no_match_returns_empty` — no false positives
  - `test_search_scoped_to_project` — results isolated to requesting user's project
  - `test_api_returns_search_snippet_with_highlight` — snippet contains `<mark>` tags
  - `test_snippet_source_is_transcript_when_matched_in_transcript`
  - `test_snippet_source_is_summary_when_matched_in_summary`
  - `test_snippet_source_is_title_when_matched_in_title`
  - `test_snippet_source_priority_title_over_summary_and_transcript`
  - `test_snippet_source_priority_summary_over_transcript`
  - `test_snippet_source_is_null_when_no_search_query`
  - `test_api_cannot_see_meetings_from_another_project_in_same_org`
  - `test_api_cannot_see_meetings_from_another_organization`

### Design Notes

- **Signal vs manual task**: `_sync_layer3_transcript` calls `meeting.save(update_fields=["transcript"])`, which fires the `post_save` signal automatically. The manual `update_meeting_search_vector.delay()` call after transcript ingest was removed as redundant — the signal handles it.
- **Snippet priority (title → summary → transcript)**: `SearchHeadline` always returns non-empty text even without a match. The priority logic checks for the presence of a `<mark>` tag in each headline to determine which field actually matched, then falls back in order.
- **Weighted search**: title has the highest weight (A) so an exact title match ranks above a transcript mention of the same keyword.
- **Permission scope**: search results go through the same `apply_meeting_knowledge_filters()` queryset used by the regular list endpoint — no additional access control layer needed.

### Test Plan

- [ ] Search a keyword that appears only in a transcript → result shows transcript snippet with `<mark>` highlight
- [ ] Search a keyword that appears in both title and transcript → title match takes priority, no snippet shown below title
- [ ] Search a keyword that matches summary but not title → summary snippet is shown
- [ ] Search returns no results for a keyword not present in any accessible meeting
- [ ] Create a meeting without a Zoom webhook → meeting is immediately searchable by title/summary
- [ ] After Zoom transcript ingest, transcript content becomes searchable with no manual step
- [ ] User cannot see meetings from another project or organization in search results
